### PR TITLE
perf(erc721): benefit from the low-level inliner

### DIFF
--- a/src/tokens/ERC721.sol
+++ b/src/tokens/ERC721.sol
@@ -100,14 +100,7 @@ abstract contract ERC721 {
         address to,
         uint256 id
     ) public virtual {
-        transferFrom(from, to, id);
-
-        require(
-            to.code.length == 0 ||
-                ERC721TokenReceiver(to).onERC721Received(msg.sender, from, id, "") ==
-                ERC721TokenReceiver.onERC721Received.selector,
-            "UNSAFE_RECIPIENT"
-        );
+        safeTransferFrom(from, to, id, "");
     }
 
     function safeTransferFrom(
@@ -178,14 +171,7 @@ abstract contract ERC721 {
     //////////////////////////////////////////////////////////////*/
 
     function _safeMint(address to, uint256 id) internal virtual {
-        _mint(to, id);
-
-        require(
-            to.code.length == 0 ||
-                ERC721TokenReceiver(to).onERC721Received(msg.sender, address(0), id, "") ==
-                ERC721TokenReceiver.onERC721Received.selector,
-            "UNSAFE_RECIPIENT"
-        );
+        _safeMint(to, id, "");
     }
 
     function _safeMint(


### PR DESCRIPTION
## Context

The [v0.8.2](https://blog.soliditylang.org/2021/04/21/custom-errors/) adds a simple inliner to the low-level optimizer of Solidity. It can inline short functions that do not contain control-flow branches or opcodes with side-effects. Long-story short: that means you save `jump` opcodes and reduce shipped code.

## Tradeoff

This improvement requires a bump to 0.8.**2**.  I am personally convinced this is worth it and the accessibility issue caused by the bump is acceptable due to the fact the bump is minor.

## Gas reporting

### Before

<img width="631" alt="Screenshot 2022-03-02 at 15 48 25" src="https://user-images.githubusercontent.com/33158502/156387532-dac62c09-69a7-44b3-a1a1-6b097263930f.png">


### After

<img width="629" alt="Screenshot 2022-03-02 at 15 48 33" src="https://user-images.githubusercontent.com/33158502/156387551-b16676ed-51ba-41f9-a34b-6996e5c33fcb.png">


## Note

Opened the PR days ago on the solmate's repository [here](https://github.com/Rari-Capital/solmate/pull/144). Awaiting team validation